### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/adityagoyal619/a7fcc9b6-d175-4e9a-8b69-51300ceaa180/f5d50f5c-5155-4492-a2f6-000a0a1749bf/_apis/work/boardbadge/eccd15a3-5cb1-4bd0-82d0-b430ebe4175f)](https://dev.azure.com/adityagoyal619/a7fcc9b6-d175-4e9a-8b69-51300ceaa180/_boards/board/t/f5d50f5c-5155-4492-a2f6-000a0a1749bf/Microsoft.RequirementCategory)
 # booking-springboot-demo
 springboot-jwt-jpa-h2db
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#1. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.